### PR TITLE
Refactored layout to ensure example content is always visible

### DIFF
--- a/examples/01_index.html
+++ b/examples/01_index.html
@@ -1,243 +1,244 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="napoleon">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Zig DataStar Streaming API</title>
+		<script type="module"
+						src="https://cdn.jsdelivr.net/gh/starfederation/datastar@release-candidate/bundles/datastar.js"></script>
+		<link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
+		<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+		<style>
+		pre,
+		code {
+			white-space: pre-line;
+		}
+		body {
+			height: calc(100vh - 128px);
+		}
+		</style>
+	</head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Zig DataStar Streaming API</title>
-  <script type="module"
-    src="https://cdn.jsdelivr.net/gh/starfederation/datastar@release-candidate/bundles/datastar.js"></script>
-  <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <style>
-    pre,
-    code {
-      white-space: pre-line;
-    }
-  </style>
-</head>
+	<body class="bg-cyan-700 mt-32">
+		<!-- Navbar -->
+		<div class="navbar bg-sky-950 text-white shadow-md fixed inset-0 z-50 h-32 flex items-center justify-between">
+			<div class="flex items-center gap-4 ">
+				<span class="btn btn-ghost text-xl text-white block md:hidden">DataStar Basic Ops</span>
+				<span class="btn btn-ghost text-xl text-center text-white hidden md:block">DataStar Basic Operations Example</span>
+				<a href="http://data-star.dev" target="_">
+					<img class="w-12 sm:w-24"
+							 src="http://data-star.dev/static/images/rocket-304e710dde0b42b15673e10937623789adf72cae569c0e0defe7ec21c0bdf293.webp">
+				</a>
+			</div>
+			<div class="avatar">
+				<div class="w-32 rounded-full">
+					<a href="https://github.com/zigster64/datastar.http.zig" target="_">
+						<img src="https://avatars.githubusercontent.com/u/72305366?v=4">
+					</a>
+				</div>
+			</div>
+		</div>
 
-<body class="bg-cyan-700">
-  <!-- Navbar -->
-  <div
-    class="navbar bg-sky-950 text-white shadow-md fixed top-0 left-0 right-0 z-50 h-32 flex items-center justify-between">
-    <div class="flex items-center gap-4">
-      <span class="btn btn-ghost text-xl text-white block md:hidden">DataStar Basic Ops</span>
-      <span class="btn btn-ghost text-xl text-white hidden md:block">DataStar Basic Operations Example</span>
-      <a href="http://data-star.dev" target="_">
-        <img class="w-12 sm:w-24"
-          src="http://data-star.dev/static/images/rocket-304e710dde0b42b15673e10937623789adf72cae569c0e0defe7ec21c0bdf293.webp">
-      </a>
-    </div>
-    <div class="avatar">
-      <div class="w-32 rounded-full">
-        <a href="https://github.com/zigster64/datastar.http.zig" target="_">
-          <img src="https://avatars.githubusercontent.com/u/72305366?v=4">
-        </a>
-      </div>
-    </div>
-  </div>
+		<!--Navigation controls to reach examples-->
+		<div id="example-nav" class="w-full h-2/12 flex flex-row justify-center items-end gap-2 mx-auto">
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#text-html-page" title="text/html">1</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#patch-elem-page" title="Patch Elements">2</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#patch-elem-opt-page" title="Patch Elements With Options">3</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#json-signals-page" title="JSON Signals">4</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#patch-signals-page" title="Patch Signals">5</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#patch-signals-if-missing-page" title="Patch Signals If Missing">6</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#patch-signals-remove-page" title="Patch Signals - Remove">7</a>
+			<a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
+				 href="#execute-script-page" title="Execute Script">8</a>
+		</div>
+		<!--carousel container-->
+		<div class="carousel rounded-box w-screen h-3/4">
+			<div id="text-html-page" class="carousel-item w-full h-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class="card-body">
+						<h2 class="card-title">(1) text/html Update</h2>
+						<p id="text-html">Click the button to update this content from a simple text/html output</p>
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/text-html')">text/html Update</button>
+						</div>
+					</div>
+					<details class="collapse bg-base-100 border-base-300 border">
+						<summary class="collapse-title font-semibold">Show Code</summary>
+						<div class="collapse-content text-sm" data-on-load="@get('/code/1')">
+							<div id='code-1' class='mockup-code w-full'></div>
+						</div>
+					</details>
+				</div>
+			</div>
+			<div id="patch-elem-page" class="carousel-item w-full h-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class="card-body">
+						<h2 class="card-title">(2) PatchElements using SSE</h2>
+						<p id="mf-patch">Click the button to use PatchElements to update this content using <i>.outer</i></p>
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/patch')">Patch Morph</button>
+						</div>
+					</div>
+					<details class="collapse bg-base-100 border-base-300 border">
+						<summary class="collapse-title font-semibold">Show Code</summary>
+						<div class="collapse-content text-sm" data-on-load="@get('/code/2')">
+							<div id='code-2' class='mockup-code w-full'></div>
+						</div>
+					</details>
+				</div>
+			</div>
+			<div id="patch-elem-opt-page" class="carousel-item w-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class="card-body" id="patch-element-card">
+						<h2 class="card-title">(3) PatchElements using SSE with Options</h2>
+						<p id="mf-patch-opts" class="border-1">Click the button to use PatchElements to update this content using
+						different options</p>
+						<p>Select Morph Options</p>
+						<div class="grid-cols-2">
+							<div>
+								<select data-bind-morph>
+									<option value="replace">Replace</option>
+									<option value="prepend">Prepend Child</option>
+									<option value="append">Append Child</option>
+									<option value="before">Before Sibling</option>
+									<option value="after">After Sibling</option>
+									<option value="remove">Remove</option>
+								</select>
+							</div>
+						</div>
+						<div class="justify-end card-actions">
+							<button class="btn btn-warning" data-on-click="@get('/patch/opts/reset')">Reset</button>
+							<button class="btn btn-primary" data-on-click="@get('/patch/opts')">Patch With Options</button>
+						</div>
+						<details class="collapse bg-base-100 border-base-300 border">
+							<summary class="collapse-title font-semibold">Show Code</summary>
+							<div class="collapse-content text-sm" data-on-load="@get('/code/3')">
+								<div id='code-3' class='mockup-code w-full'></div>
+							</div>
+						</details>
+					</div>
+				</div>
+			</div>
+			<div id="json-signals-page" class="carousel-item w-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class="card-body">
+						<h2 class="card-title">(4) Patch Signals using JSON</h2>
+						<p class="border-1">Click the button to use JSON to update the signals on the
+						card</p>
+						<input type="text" placeholder="fooj" data-bind-fooj />
+						<input type="text" placeholder="barj" data-bind-barj />
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/patch/json')">JSON Update</button>
+						</div>
+						<details class="collapse bg-base-100 border-base-300 border">
+							<summary class="collapse-title font-semibold">Show Code</summary>
+							<div class="collapse-content text-sm" data-on-load="@get('/code/4')">
+								<div id='code-4' class='mockup-code w-full'></div>
+							</div>
+						</details>
+					</div>
+				</div>
+			</div>
+			<div id="patch-signals-page" class="carousel-item w-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class="card-body">
+						<h2 class="card-title">(5) Patch Signals using SSE</h2>
+						<p class="border-1">Click the button to use PatchSignals to update the signals on the
+						card</p>
+						<input type="text" placeholder="foo" data-bind-foo />
+						<input type="text" placeholder="bar" data-bind-bar />
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/patch/signals')">Patch Signals</button>
+						</div>
+						<details class="collapse bg-base-100 border-base-300 border">
+							<summary class="collapse-title font-semibold">Show Code</summary>
+							<div class="collapse-content text-sm" data-on-load="@get('/code/5')">
+								<div id='code-5' class='mockup-code w-full'></div>
+							</div>
+						</details>
+					</div>
+				</div>
+			</div>
+			<div id="patch-signals-if-missing-page" class="carousel-item w-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class="card-body">
+						<h2 class="card-title">(6) Patch Signals using SSE - only if missing</h2>
+						<p class="border-1">Click the button to use PatchSignals to update the signals on the
+						card, but only ones that are missing, so initially thats just 'bar', then nothing updates after that</p>
+						<code class="border-1 bg-gray-400" data-json-signals></code>
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/patch/signals/onlymissing')">Patch Signals if
+								Missing</button>
+						</div>
+						<details class="collapse bg-base-100 border-base-300 border">
+							<summary class="collapse-title font-semibold">Show Code</summary>
+							<div class="collapse-content text-sm" data-on-load="@get('/code/6')">
+								<div id='code-6' class='mockup-code w-full'></div>
+							</div>
+						</details>
+					</div>
+				</div>
+			</div>
+			<div id="patch-signals-remove-page" class="carousel-item w-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class=" card-body">
+						<h2 class="card-title">(7) Patch Signals using SSE - Remove</h2>
+						<p class="border-1">Click the button to use PatchSignals to remove the signals on the
+						card</p>
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/patch/signals/remove')">Remove Signals</button>
+						</div>
+						<details class="collapse bg-base-100 border-base-300 border">
+							<summary class="collapse-title font-semibold">Show Code</summary>
+							<div class="collapse-content text-sm" data-on-load="@get('/code/7')">
+								<div id='code-7' class='mockup-code w-full'></div>
+							</div>
+						</details>
+					</div>
+				</div>
+			</div>
+			<div id="execute-script-page" class="carousel-item w-full flex justify-center items-center">
+				<div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
+					<div class=" card-body">
+						<h2 class="card-title">(8) Execute Script using SSE</h2>
+						<p class="border-1">WIP - Click the button to execute the below script! Check the window to see if it worked!
+						</p>
+						<code class="border-1 bg-gray-400">console.log('Running from executescript!');</code>
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/executescript/1')">Execute Script</button>
+						</div>
+						<code class="border-1 bg-gray-400">
+							parent = document.querySelector('#executescript-card');
+							console.log(parent.outerHTML);
+						</code>
+						<div class="justify-end card-actions">
+							<button class="btn btn-primary" data-on-click="@get('/executescript/2')">Execute Script</button>
+						</div>
+						<details class="collapse bg-base-100 border-base-300 border">
+							<summary class="collapse-title font-semibold">Show Code</summary>
+							<div class="collapse-content text-sm" data-on-load="@get('/code/8')">
+								<div id='code-8' class='mockup-code w-full'></div>
+							</div>
+						</details>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- top header div is fixed height 32, so place this 2 below ... hacky but works -->
+		<!--<div class="hero min-h-screen bg-cover bg-center bg-no-repeat relative"> Your real content goes here -->
+		<!-- 	<div class="relative z-10">-->
+		<!-- 		<div class="flex-col items-start">-->
+		<!-- 		</div>-->
+		<!-- 	</div>-->
+		<!-- </div>-->
 
-  <!--carousel container-->
-  <div class="carousel carousel-center rounded-box w-screen h-screen t-40">
-    <div id="text-html-page" class="carousel-item w-full h-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class="card-body">
-          <h2 class="card-title">(1) text/html Update</h2>
-          <p id="text-html">Click the button to update this content from a simple text/html output</p>
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/text-html')">text/html Update</button>
-          </div>
-        </div>
-        <details class="collapse bg-base-100 border-base-300 border">
-          <summary class="collapse-title font-semibold">Show Code</summary>
-          <div class="collapse-content text-sm" data-on-load="@get('/code/1')">
-            <div id='code-1' class='mockup-code w-full'></div>
-          </div>
-        </details>
-      </div>
-    </div>
-    <div id="patch-elem-page" class="carousel-item w-full h-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class="card-body">
-          <h2 class="card-title">(2) PatchElements using SSE</h2>
-          <p id="mf-patch">Click the button to use PatchElements to update this content using <i>.outer</i></p>
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/patch')">Patch Morph</button>
-          </div>
-        </div>
-        <details class="collapse bg-base-100 border-base-300 border">
-          <summary class="collapse-title font-semibold">Show Code</summary>
-          <div class="collapse-content text-sm" data-on-load="@get('/code/2')">
-            <div id='code-2' class='mockup-code w-full'></div>
-          </div>
-        </details>
-      </div>
-    </div>
-    <div id="patch-elem-opt-page" class="carousel-item w-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class="card-body" id="patch-element-card">
-          <h2 class="card-title">(3) PatchElements using SSE with Options</h2>
-          <p id="mf-patch-opts" class="border-1">Click the button to use PatchElements to update this content using
-            different options</p>
-          <p>Select Morph Options</p>
-          <div class="grid-cols-2">
-            <div>
-              <select data-bind-morph>
-                <option value="replace">Replace</option>
-                <option value="prepend">Prepend Child</option>
-                <option value="append">Append Child</option>
-                <option value="before">Before Sibling</option>
-                <option value="after">After Sibling</option>
-                <option value="remove">Remove</option>
-              </select>
-            </div>
-          </div>
-          <div class="justify-end card-actions">
-            <button class="btn btn-warning" data-on-click="@get('/patch/opts/reset')">Reset</button>
-            <button class="btn btn-primary" data-on-click="@get('/patch/opts')">Patch With Options</button>
-          </div>
-          <details class="collapse bg-base-100 border-base-300 border">
-            <summary class="collapse-title font-semibold">Show Code</summary>
-            <div class="collapse-content text-sm" data-on-load="@get('/code/3')">
-              <div id='code-3' class='mockup-code w-full'></div>
-            </div>
-          </details>
-        </div>
-      </div>
-    </div>
-    <div id="json-signals-page" class="carousel-item w-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class="card-body">
-          <h2 class="card-title">(4) Patch Signals using JSON</h2>
-          <p class="border-1">Click the button to use JSON to update the signals on the
-            card</p>
-          <input type="text" placeholder="fooj" data-bind-fooj />
-          <input type="text" placeholder="barj" data-bind-barj />
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/patch/json')">JSON Update</button>
-          </div>
-          <details class="collapse bg-base-100 border-base-300 border">
-            <summary class="collapse-title font-semibold">Show Code</summary>
-            <div class="collapse-content text-sm" data-on-load="@get('/code/4')">
-              <div id='code-4' class='mockup-code w-full'></div>
-            </div>
-          </details>
-        </div>
-      </div>
-    </div>
-    <div id="patch-signals-page" class="carousel-item w-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class="card-body">
-          <h2 class="card-title">(5) Patch Signals using SSE</h2>
-          <p class="border-1">Click the button to use PatchSignals to update the signals on the
-            card</p>
-          <input type="text" placeholder="foo" data-bind-foo />
-          <input type="text" placeholder="bar" data-bind-bar />
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/patch/signals')">Patch Signals</button>
-          </div>
-          <details class="collapse bg-base-100 border-base-300 border">
-            <summary class="collapse-title font-semibold">Show Code</summary>
-            <div class="collapse-content text-sm" data-on-load="@get('/code/5')">
-              <div id='code-5' class='mockup-code w-full'></div>
-            </div>
-          </details>
-        </div>
-      </div>
-    </div>
-    <div id="patch-signals-if-missing-page" class="carousel-item w-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class="card-body">
-          <h2 class="card-title">(6) Patch Signals using SSE - only if missing</h2>
-          <p class="border-1">Click the button to use PatchSignals to update the signals on the
-            card, but only ones that are missing, so initially thats just 'bar', then nothing updates after that</p>
-          <code class="border-1 bg-gray-400" data-json-signals></code>
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/patch/signals/onlymissing')">Patch Signals if
-              Missing</button>
-          </div>
-          <details class="collapse bg-base-100 border-base-300 border">
-            <summary class="collapse-title font-semibold">Show Code</summary>
-            <div class="collapse-content text-sm" data-on-load="@get('/code/6')">
-              <div id='code-6' class='mockup-code w-full'></div>
-            </div>
-          </details>
-        </div>
-      </div>
-    </div>
-    <div id="patch-signals-remove-page" class="carousel-item w-full m-auto">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class=" card-body">
-          <h2 class="card-title">(7) Patch Signals using SSE - Remove</h2>
-          <p class="border-1">Click the button to use PatchSignals to remove the signals on the
-            card</p>
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/patch/signals/remove')">Remove Signals</button>
-          </div>
-          <details class="collapse bg-base-100 border-base-300 border">
-            <summary class="collapse-title font-semibold">Show Code</summary>
-            <div class="collapse-content text-sm" data-on-load="@get('/code/7')">
-              <div id='code-7' class='mockup-code w-full'></div>
-            </div>
-          </details>
-        </div>
-      </div>
-    </div>
-    <div id="execute-script-page" class="carousel-item w-full m-auto" id="executescript-card">
-      <div class="card w-8/12 bg-slate-300 card-lg shadow-sm m-auto">
-        <div class=" card-body">
-          <h2 class="card-title">(8) Execute Script using SSE</h2>
-          <p class="border-1">WIP - Click the button to execute the below script! Check the window to see if it worked!
-          </p>
-          <code class="border-1 bg-gray-400">console.log('Running from executescript!');</code>
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/executescript/1')">Execute Script</button>
-          </div>
-          <code class="border-1 bg-gray-400">
-            parent = document.querySelector('#executescript-card');
-            console.log(parent.outerHTML);
-          </code>
-          <div class="justify-end card-actions">
-            <button class="btn btn-primary" data-on-click="@get('/executescript/2')">Execute Script</button>
-          </div>
-          <details class="collapse bg-base-100 border-base-300 border">
-            <summary class="collapse-title font-semibold">Show Code</summary>
-            <div class="collapse-content text-sm" data-on-load="@get('/code/8')">
-              <div id='code-8' class='mockup-code w-full'></div>
-            </div>
-          </details>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- top header div is fixed height 32, so place this 2 below ... hacky but works -->
-  <div class="fixed left-1/4 top-34 w-6/12 h-1/12 flex flex-row justify-center align-center gap-1">
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#text-html-page" title="text/html">1</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#patch-elem-page" title="Patch Elements">2</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#patch-elem-opt-page" title="Patch Elements With Options">3</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#json-signals-page" title="JSON Signals">4</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#patch-signals-page" title="Patch Signals">5</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#patch-signals-if-missing-page" title="Patch Signals If Missing">6</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#patch-signals-remove-page" title="Patch Signals - Remove">7</a>
-    <a class="text-xl text-center p-4 rounded-md bg-blue-400 border-solid border-gray-700 border-2"
-      href="#execute-script-page" title="Execute Script">8</a>
-  </div>
-
-  <!--<div class="hero min-h-screen bg-cover bg-center bg-no-repeat relative" <!-- Your real content goes here -->-->
-  <!--	<div class="relative z-10">-->
-  <!--		<div class="flex-col items-start">-->
-  <!--		</div>-->
-  <!--	</div>-->
-  <!--</div>-->
-
-</body>
+	</body>
 
 </html>


### PR DESCRIPTION
I noticed that certain examples of heights greater than about 3/4 of the page size were overlapping with the navigation buttons or possibly causing overflow, so I changed the size and margin of the body to account for the nav bar and made cards scrollable once they reach overflow on their block.